### PR TITLE
[WO-555] Remove cleartext prefix to encrypted messages

### DIFF
--- a/src/js/app-config.js
+++ b/src/js/app-config.js
@@ -106,7 +106,6 @@ define(function(require) {
         fallbackSubject: '(no subject)',
         invitationSubject: 'Invitation to a private conversation',
         invitationMessage: 'Hi,\n\nI use Whiteout Mail to send and receive encrypted email. I would like to exchange encrypted messages with you as well.\n\nPlease install the Whiteout Mail application. This application makes it easy to read and write messages securely with PGP encryption applied.\n\nGo to the Whiteout Networks homepage to learn more and to download the application: https://whiteout.io\n\n',
-        message: 'Hi,\n\nthis is a private conversation. To read my encrypted message below, open it in Whiteout Mail: https://whiteout.io/#product\n\n\n',
         signature: '\n\n\n--\nSent from Whiteout Mail - https://whiteout.io\n\nMy PGP key: ',
         webSite: 'http://whiteout.io',
         verificationSubject: '[whiteout] New public key uploaded',

--- a/src/js/dao/email-dao.js
+++ b/src/js/dao/email-dao.js
@@ -1010,7 +1010,6 @@ define(function(require) {
         // mime encode, sign, encrypt and send email via smtp
         self._pgpMailer.send({
             encrypt: true,
-            cleartextMessage: str.message,
             smtpclient: options.smtpclient, // filled solely in the integration test, undefined in normal usage
             mail: options.email,
             publicKeysArmored: options.email.publicKeysArmored

--- a/test/integration/email-dao-test.js
+++ b/test/integration/email-dao-test.js
@@ -806,8 +806,10 @@ define(function(require) {
                 sinon.stub(smtpServer, 'onmail', function(mail) {
                     expect(mail.from).to.equal(testAccount.user);
                     expect(mail.to).to.deep.equal([testAccount.user]);
-                    expect(/^Content-Type: multipart\/mixed/.test(mail.body)).to.be.true;
-                    expect(mail.body).to.contain('this is a private conversation');
+
+                    expect(/^Content-Type: multipart\/mixed/.test(mail.body)).to.be.false;
+                    expect(/^Content-Type: multipart\/encrypted/.test(mail.body)).to.be.true;
+                    expect(mail.body).to.contain('LS0tLS1CRUdJTiBQR1AgTUVTU0FHRS0tLS0tDQpWZXJzaW9uOiBPcGVuUEdQLmpzIHYwLjcuMg0K'); // one line of the ciphertext
                 });
 
                 emailDao.sendEncrypted({

--- a/test/unit/email-dao-test.js
+++ b/test/unit/email-dao-test.js
@@ -9,9 +9,7 @@ define(function(require) {
         PGP = require('js/crypto/pgp'),
         DeviceStorageDAO = require('js/dao/devicestorage-dao'),
         mailreader = require('mailreader'),
-        appcfg = require('js/app-config'),
-        str = appcfg.string,
-        cfg = appcfg.config,
+        cfg = require('js/app-config').config,
         expect = chai.expect;
 
 
@@ -1559,7 +1557,6 @@ define(function(require) {
 
                     pgpMailerStub.send.withArgs({
                         encrypt: true,
-                        cleartextMessage: str.message,
                         mail: dummyMail,
                         smtpclient: undefined,
                         publicKeysArmored: publicKeys
@@ -1584,7 +1581,6 @@ define(function(require) {
 
                     pgpMailerStub.send.withArgs({
                         encrypt: true,
-                        cleartextMessage: str.message,
                         mail: dummyMail,
                         smtpclient: undefined,
                         publicKeysArmored: publicKeys


### PR DESCRIPTION
Removes the following message header:

```
Hi,

this is a private conversation. To read my encrypted message below, open it in Whiteout Mail: https://whiteout.io/#product
```
