### PR TITLE
[WO-643] Refactor initialization workflow

### DIFF
--- a/src/js/controller/mail-list.js
+++ b/src/js/controller/mail-list.js
@@ -71,7 +71,9 @@ var MailListCtrl = function($scope, $routeParams) {
         }
         firstSelect = false;
 
-        keychainDao.refreshKeyForUserId(email.from[0].address, onKeyRefreshed);
+        keychainDao.refreshKeyForUserId({
+            userId: email.from[0].address
+        }, onKeyRefreshed);
 
         function onKeyRefreshed(err) {
             if (err) {

--- a/src/js/controller/write.js
+++ b/src/js/controller/write.js
@@ -229,7 +229,9 @@ var WriteCtrl = function($scope, $filter, $q) {
         if (keychainDao) {
             // check if to address is contained in known public keys
             // when we write an email, we always need to work with the latest keys available
-            keychainDao.refreshKeyForUserId(recipient.address, function(err, key) {
+            keychainDao.refreshKeyForUserId({
+                userId: recipient.address
+            }, function(err, key) {
                 if (err) {
                     $scope.onError(err);
                     return;

--- a/test/unit/email-dao-test.js
+++ b/test/unit/email-dao-test.js
@@ -148,32 +148,14 @@ describe('Email DAO unit tests', function() {
             initFoldersStub = sinon.stub(dao, '_initFoldersFromDisk');
         });
 
-        it('should initialize folders and return keypair', function(done) {
-            keychainStub.getUserKeyPair.withArgs(emailAddress).yieldsAsync(null, mockKeyPair);
+        it('should initialize folders', function(done) {
             initFoldersStub.yieldsAsync();
 
             dao.init({
                 account: account
-            }, function(err, keypair) {
+            }, function(err) {
                 expect(err).to.not.exist;
-                expect(keypair).to.exist;
-                expect(keychainStub.getUserKeyPair.calledOnce).to.be.true;
                 expect(initFoldersStub.calledOnce).to.be.true;
-
-                done();
-            });
-        });
-
-        it('should fail when keychain errors', function(done) {
-            keychainStub.getUserKeyPair.yieldsAsync({});
-
-            dao.init({
-                account: account
-            }, function(err, keypair) {
-                expect(err).to.exist;
-                expect(keypair).to.not.exist;
-                expect(keychainStub.getUserKeyPair.calledOnce).to.be.true;
-                expect(initFoldersStub.called).to.be.false;
 
                 done();
             });

--- a/test/unit/keychain-dao-test.js
+++ b/test/unit/keychain-dao-test.js
@@ -85,7 +85,9 @@ describe('Keychain DAO unit tests', function() {
         it('should not find a key', function(done) {
             getPubKeyStub.yields();
 
-            keychainDao.refreshKeyForUserId(testUser, function(err, key) {
+            keychainDao.refreshKeyForUserId({
+                userId: testUser
+            }, function(err, key) {
                 expect(err).to.not.exist;
                 expect(key).to.not.exist;
 
@@ -97,7 +99,9 @@ describe('Keychain DAO unit tests', function() {
             getPubKeyStub.yields(null, oldKey);
             pubkeyDaoStub.get.withArgs(oldKey._id).yields(null, oldKey);
 
-            keychainDao.refreshKeyForUserId(testUser, function(err, key) {
+            keychainDao.refreshKeyForUserId({
+                userId: testUser
+            }, function(err, key) {
                 expect(err).to.not.exist;
                 expect(key).to.to.equal(oldKey);
 
@@ -121,7 +125,33 @@ describe('Keychain DAO unit tests', function() {
             lawnchairDaoStub.remove.withArgs('publickey_' + oldKey._id).yields();
             lawnchairDaoStub.persist.withArgs('publickey_' + newKey._id, newKey).yields();
 
-            keychainDao.refreshKeyForUserId(testUser, function(err, key) {
+            keychainDao.refreshKeyForUserId({
+                userId: testUser
+            }, function(err, key) {
+                expect(err).to.not.exist;
+                expect(key).to.equal(newKey);
+
+                expect(getPubKeyStub.calledOnce).to.be.true;
+                expect(pubkeyDaoStub.get.calledOnce).to.be.true;
+                expect(pubkeyDaoStub.getByUserId.calledOnce).to.be.true;
+                expect(lawnchairDaoStub.remove.calledOnce).to.be.true;
+                expect(lawnchairDaoStub.persist.calledOnce).to.be.true;
+
+                done();
+            });
+        });
+
+        it('should update key without approval', function(done) {
+            getPubKeyStub.yields(null, oldKey);
+            pubkeyDaoStub.get.withArgs(oldKey._id).yields();
+            pubkeyDaoStub.getByUserId.withArgs(testUser).yields(null, newKey);
+            lawnchairDaoStub.remove.withArgs('publickey_' + oldKey._id).yields();
+            lawnchairDaoStub.persist.withArgs('publickey_' + newKey._id, newKey).yields();
+
+            keychainDao.refreshKeyForUserId({
+                userId: testUser,
+                overridePermission: true
+            }, function(err, key) {
                 expect(err).to.not.exist;
                 expect(key).to.equal(newKey);
 
@@ -146,7 +176,9 @@ describe('Keychain DAO unit tests', function() {
             };
             lawnchairDaoStub.remove.withArgs('publickey_' + oldKey._id).yields();
 
-            keychainDao.refreshKeyForUserId(testUser, function(err, key) {
+            keychainDao.refreshKeyForUserId({
+                userId: testUser
+            }, function(err, key) {
                 expect(err).to.not.exist;
                 expect(key).to.not.exist;
 
@@ -167,7 +199,9 @@ describe('Keychain DAO unit tests', function() {
                 code: 42
             });
 
-            keychainDao.refreshKeyForUserId(testUser, function(err, key) {
+            keychainDao.refreshKeyForUserId({
+                userId: testUser
+            }, function(err, key) {
                 expect(err).to.not.exist;
                 expect(key).to.to.equal(oldKey);
 
@@ -191,7 +225,9 @@ describe('Keychain DAO unit tests', function() {
                 cb(false);
             };
 
-            keychainDao.refreshKeyForUserId(testUser, function(err, key) {
+            keychainDao.refreshKeyForUserId({
+                userId: testUser
+            }, function(err, key) {
                 expect(err).to.not.exist;
                 expect(key).to.equal(oldKey);
 
@@ -208,7 +244,9 @@ describe('Keychain DAO unit tests', function() {
         it('should not remove manually imported key', function(done) {
             getPubKeyStub.yields(null, importedKey);
 
-            keychainDao.refreshKeyForUserId(testUser, function(err, key) {
+            keychainDao.refreshKeyForUserId({
+                userId: testUser
+            }, function(err, key) {
                 expect(err).to.not.exist;
                 expect(key).to.equal(importedKey);
 
@@ -225,7 +263,9 @@ describe('Keychain DAO unit tests', function() {
                 code: 42
             });
 
-            keychainDao.refreshKeyForUserId(testUser, function(err, key) {
+            keychainDao.refreshKeyForUserId({
+                userId: testUser
+            }, function(err, key) {
                 expect(err).to.not.exist;
                 expect(key).to.to.equal(oldKey);
 
@@ -251,7 +291,9 @@ describe('Keychain DAO unit tests', function() {
             lawnchairDaoStub.remove.withArgs('publickey_' + oldKey._id).yields();
             lawnchairDaoStub.persist.yields({});
 
-            keychainDao.refreshKeyForUserId(testUser, function(err, key) {
+            keychainDao.refreshKeyForUserId({
+                userId: testUser
+            }, function(err, key) {
                 expect(err).to.exist;
                 expect(key).to.not.exist;
 
@@ -275,7 +317,9 @@ describe('Keychain DAO unit tests', function() {
             };
             lawnchairDaoStub.remove.yields({});
 
-            keychainDao.refreshKeyForUserId(testUser, function(err, key) {
+            keychainDao.refreshKeyForUserId({
+                userId: testUser
+            }, function(err, key) {
                 expect(err).to.exist;
                 expect(key).to.not.exist;
 
@@ -301,7 +345,9 @@ describe('Keychain DAO unit tests', function() {
             lawnchairDaoStub.remove.withArgs('publickey_' + oldKey._id).yields();
             lawnchairDaoStub.persist.yields({});
 
-            keychainDao.refreshKeyForUserId(testUser, function(err, key) {
+            keychainDao.refreshKeyForUserId({
+                userId: testUser
+            }, function(err, key) {
                 expect(err).to.exist;
                 expect(key).to.not.exist;
 
@@ -319,7 +365,9 @@ describe('Keychain DAO unit tests', function() {
             getPubKeyStub.yields(null, oldKey);
             pubkeyDaoStub.get.withArgs(oldKey._id).yields({});
 
-            keychainDao.refreshKeyForUserId(testUser, function(err, key) {
+            keychainDao.refreshKeyForUserId({
+                userId: testUser
+            }, function(err, key) {
                 expect(err).to.exist;
                 expect(key).to.not.exist;
 

--- a/test/unit/mail-list-ctrl-test.js
+++ b/test/unit/mail-list-ctrl-test.js
@@ -364,7 +364,9 @@ describe('Mail List controller unit test', function() {
                 }
             };
 
-            keychainMock.refreshKeyForUserId.withArgs(mail.from[0].address).yields();
+            keychainMock.refreshKeyForUserId.withArgs({
+                userId: mail.from[0].address
+            }).yields();
 
             scope.select(mail);
 
@@ -397,7 +399,7 @@ describe('Mail List controller unit test', function() {
                 }
             };
 
-            keychainMock.refreshKeyForUserId.withArgs(mail.from[0].address).yields();
+            keychainMock.refreshKeyForUserId.withArgs({userId: mail.from[0].address}).yields();
 
             scope.select(mail);
 

--- a/test/unit/write-ctrl-test.js
+++ b/test/unit/write-ctrl-test.js
@@ -192,7 +192,9 @@ describe('Write controller unit test', function() {
                 address: 'asds@example.com'
             };
 
-            keychainMock.refreshKeyForUserId.withArgs(recipient.address).yields({
+            keychainMock.refreshKeyForUserId.withArgs({
+                userId: recipient.address
+            }).yields({
                 errMsg: '404 not found yadda yadda'
             });
 
@@ -212,7 +214,9 @@ describe('Write controller unit test', function() {
                 address: 'asdf@example.com'
             };
 
-            keychainMock.refreshKeyForUserId.withArgs(recipient.address).yields(null, {
+            keychainMock.refreshKeyForUserId.withArgs({
+                userId: recipient.address
+            }).yields(null, {
                 userId: 'asdf@example.com'
             });
 
@@ -240,7 +244,9 @@ describe('Write controller unit test', function() {
                 }]
             };
 
-            keychainMock.refreshKeyForUserId.withArgs(recipient.address).yields(null, key);
+            keychainMock.refreshKeyForUserId.withArgs({
+                userId: recipient.address
+            }).yields(null, key);
 
             scope.$digest = function() {
                 expect(recipient.key).to.deep.equal(key);


### PR DESCRIPTION
- Move initialization pre-flight checks to app-controller
- Refresh cached public keys for user during incomplete setups
- Reorder redirect checks in login ctrl from most specific (pubkey + privkey) to most generic (no keys)
- Add overridePermission flag to KeychainDAO.refreshKeyForUserId to refresh w/o asking for user permission
