### PR TITLE
Fix #113

### DIFF
--- a/src/js/controller/app/read-sandbox.js
+++ b/src/js/controller/app/read-sandbox.js
@@ -27,6 +27,7 @@ window.onmessage = function(e) {
     document.body.innerHTML = html;
 
     attachClickHandlers();
+    attachKeyPressHandlers();
 };
 
 /**
@@ -53,6 +54,18 @@ function attachClickHandlers() {
         var re = /^(([^<>()[\]\\.,;:\s@\"]+(\.[^<>()[\]\\.,;:\s@\"]+)*)|(\".+\"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
         return re.test(text);
     }
+}
+
+function attachKeyPressHandlers() {
+    window.onkeydown = function(e) {
+        e.preventDefault();
+        window.parentIFrame.sendMessage({
+            type: 'keydown',
+            keyCode: e.keyCode,
+            ctrlKey: e.ctrlKey,
+            metaKey: e.metaKey,
+        });
+    };
 }
 
 /**

--- a/src/js/directive/read.js
+++ b/src/js/directive/read.js
@@ -78,6 +78,15 @@ ngModule.directive('frameLoad', function($window) {
                             address: e.message.address
                         }]
                     });
+                } else if (e.message.type === 'keydown') {
+                    var ev = new Event("keydown", {
+                        "bubbles":true,
+                        "cancelable":false
+                    });
+                    ev.keyCode = e.message.keyCode,
+                    ev.ctrlKey = e.message.ctrlKey,
+                    ev.metaKey = e.message.metaKey,
+                    window.dispatchEvent(evt);
                 }
             }
         });

--- a/src/js/directive/read.js
+++ b/src/js/directive/read.js
@@ -86,7 +86,7 @@ ngModule.directive('frameLoad', function($window) {
                     ev.keyCode = e.message.keyCode,
                     ev.ctrlKey = e.message.ctrlKey,
                     ev.metaKey = e.message.metaKey,
-                    window.dispatchEvent(evt);
+                    window.dispatchEvent(ev);
                 }
             }
         });


### PR DESCRIPTION
Hi, first try at contributing.

This fixes the bug of the usual keypress not working when the email text is selected.

I narrowed down the problem to the read email sandbox iframe not having attached handlers, and this is fixed by attaching keypress handlers in `read-sandbox.js` similar to how click handlers are attached in the same file.
The handlers then sends a message to the parent frame.
The issue I faced here is that the `Event` object cannot be directly sent in the message, so I sent the attributes that are needed `keyCode`, `ctrlKey`, and `metaKey`, to the parent frame, which reconstructs a keypress event object with those attributes, and dispatches it.

This PR is lacking test, would love advice on how to go about doing that, thanks!